### PR TITLE
[WIP] Scrape node stats using proxy when usingMetricsProxy label set to true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ all: metrics-server
 # -----------
 
 src_deps=$(shell find pkg cmd -type f -name "*.go")
-PKG:=sigs.k8s.io/metrics-server/pkg
+PKG:=./pkg
 LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
 metrics-server: $(src_deps)
-	GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o metrics-server sigs.k8s.io/metrics-server/cmd/metrics-server
+	GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o metrics-server ./cmd/metrics-server
 
 pkg/scraper/types_easyjson.go: pkg/scraper/types.go
-	go install -mod=readonly github.com/mailru/easyjson
+	go install -mod=readonly github.com/mailru/easyjson/...
 	$(GOPATH)/bin/easyjson -all pkg/scraper/types.go
 
 pkg/api/generated/openapi/zz_generated.openapi.go: go.mod

--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -58,6 +58,8 @@ type Options struct {
 	KubeletClientKeyFile         string
 	KubeletClientCertFile        string
 
+	KubeletProxyServerAddress string
+
 	ShowVersion bool
 
 	DeprecatedCompletelyInsecureKubelet bool
@@ -103,6 +105,7 @@ func (o *Options) Flags(cmd *cobra.Command) {
 	flags.StringVar(&o.KubeletCAFile, "kubelet-certificate-authority", "", "Path to the CA to use to validate the Kubelet's serving certificates.")
 	flags.StringVar(&o.KubeletClientKeyFile, "kubelet-client-key", "", "Path to a client key file for TLS.")
 	flags.StringVar(&o.KubeletClientCertFile, "kubelet-client-certificate", "", "Path to a client cert file for TLS.")
+	flags.StringVar(&o.KubeletProxyServerAddress, "", "kubelet-proxy-server-address", "URL of Reverse Proxy used to reach on-prem nodes.")
 
 	flags.BoolVar(&o.ShowVersion, "version", false, "Show version")
 
@@ -200,11 +203,12 @@ func (o Options) restConfig() (*rest.Config, error) {
 
 func (o Options) kubeletConfig(restConfig *rest.Config) *scraper.KubeletClientConfig {
 	config := &scraper.KubeletClientConfig{
-		Scheme:              "https",
-		DefaultPort:         o.KubeletPort,
-		AddressTypePriority: o.addressResolverConfig(),
-		UseNodeStatusPort:   o.KubeletUseNodeStatusPort,
-		Client:              *rest.CopyConfig(restConfig),
+		Scheme:                    "https",
+		DefaultPort:               o.KubeletPort,
+		AddressTypePriority:       o.addressResolverConfig(),
+		UseNodeStatusPort:         o.KubeletUseNodeStatusPort,
+		Client:                    *rest.CopyConfig(restConfig),
+		KubeletProxyServerAddress: o.KubeletProxyServerAddress,
 	}
 	if o.DeprecatedCompletelyInsecureKubelet {
 		config.Scheme = "http"

--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -105,7 +105,7 @@ func (o *Options) Flags(cmd *cobra.Command) {
 	flags.StringVar(&o.KubeletCAFile, "kubelet-certificate-authority", "", "Path to the CA to use to validate the Kubelet's serving certificates.")
 	flags.StringVar(&o.KubeletClientKeyFile, "kubelet-client-key", "", "Path to a client key file for TLS.")
 	flags.StringVar(&o.KubeletClientCertFile, "kubelet-client-certificate", "", "Path to a client cert file for TLS.")
-	flags.StringVar(&o.KubeletProxyServerAddress, "", "kubelet-proxy-server-address", "URL of Reverse Proxy used to reach on-prem nodes.")
+	flags.StringVar(&o.KubeletProxyServerAddress, "kubelet-proxy-server-address", "", "URL of Reverse Proxy used to reach on-prem nodes.")
 
 	flags.BoolVar(&o.ShowVersion, "version", false, "Show version")
 

--- a/pkg/scraper/client.go
+++ b/pkg/scraper/client.go
@@ -100,7 +100,7 @@ func (kc *kubeletClient) GetSummary(ctx context.Context, node *corev1.Node) (*Su
 	var rawQuery string
 	if useProxy, _ := strconv.ParseBool(node.ObjectMeta.Labels["usingMetricsProxy"]); useProxy && kc.KubeletProxyServerAddress != "" {
 		host = kc.KubeletProxyServerAddress
-		rawQuery = fmt.Sprintf("only_cpu_and_memory=true&nodeIp=%v&nodePort=%v", addr, nodeStatusPort)
+		rawQuery = fmt.Sprintf("only_cpu_and_memory=true&nodeIp=%v&nodePort=%v", addr, port)
 	} else {
 		host = net.JoinHostPort(addr, strconv.Itoa(port))
 		rawQuery = "only_cpu_and_memory=true"

--- a/pkg/scraper/client_test.go
+++ b/pkg/scraper/client_test.go
@@ -1,0 +1,173 @@
+package scraper
+
+// https://golang.org/pkg/net/http/httptest/#Server.Client
+// https://erikwinter.nl/articles/2020/unit-test-outbound-http-requests-in-golang/
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/metrics-server/pkg/utils"
+)
+
+var _ = Describe("Client", func() {
+	var (
+		mockRecorder     = &MockServerRecorder{Requests: []*http.Request{}}
+		mockServer       = newMockServer(mockRecorder, newMockServerProcedure("", true, false), newMockServerProcedure("", false, true))
+		mockServerURL, _ = url.Parse(mockServer.URL)
+		proxyServerAddr  = net.JoinHostPort(mockServerURL.Hostname(), mockServerURL.Port())
+		nodeAddr         = mockServerURL.Hostname()
+		nodePort, _      = strconv.Atoi(mockServerURL.Port())
+		httpClient       = mockServer.Client()
+		addrResolver     = utils.NewPriorityNodeAddressResolver([]corev1.NodeAddressType{corev1.NodeInternalIP})
+		kubeletClient    = makeKubelet(nodePort, httpClient, addrResolver, proxyServerAddr)
+	)
+	BeforeEach(func() {
+		mockRecorder.Requests = []*http.Request{}
+	})
+	Context("when node doesn't have label to use proxy", func() {
+		It("should connect to the node directly", func() {
+			By("invoking GetSummary with a context timeout of 5 seconds")
+			nodeWOProxy := makeNode("node1", "node1.somedomain", nodeAddr, true, false)
+
+			timeoutCtx, doneWithWork := context.WithTimeout(context.Background(), 4*time.Second)
+			_, err := kubeletClient.GetSummary(timeoutCtx, nodeWOProxy)
+			doneWithWork()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring only 1 request was received by the mock server")
+			Expect(mockRecorder.Requests).Should(HaveLen(1))
+
+			By("ensuring that request only contains parameter only_cpu_and_memory=true and not nodeIp nor nodePort")
+			Expect(mockRecorder.Requests[0].URL.RawQuery).To(
+				SatisfyAll(
+					ContainSubstring("only_cpu_and_memory=true"),
+					Not(ContainSubstring("nodeIp=")),
+					Not(ContainSubstring("nodePort="))))
+		})
+	})
+	Context("when node has label to use proxy", func() {
+		It("should connect to the proxy instead of the node", func() {
+			By("invoking GetSummary with a context timeout of 5 seconds")
+			nodeWProxy := makeNode("node1", "node1.somedomain", nodeAddr, true, true)
+
+			timeoutCtx, doneWithWork := context.WithTimeout(context.Background(), 4*time.Second)
+			_, err := kubeletClient.GetSummary(timeoutCtx, nodeWProxy)
+			doneWithWork()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring only 1 request was received by the mock server")
+			Expect(mockRecorder.Requests).Should(HaveLen(1))
+
+			By("ensuring that request contains parameters only_cpu_and_memory, nodeIp and nodePort")
+			Expect(mockRecorder.Requests[0].URL.RawQuery).To(
+				SatisfyAll(
+					ContainSubstring("only_cpu_and_memory=true"),
+					ContainSubstring("nodeIp="),
+					ContainSubstring("nodePort=")))
+
+			By("ensuring that NodeIP is correct")
+			Expect(mockRecorder.Requests[0].URL.RawQuery).To(ContainSubstring(fmt.Sprint("nodeIp=", nodeAddr)))
+
+			By("ensuring that NodePort is correct")
+			Expect(mockRecorder.Requests[0].URL.RawQuery).To(ContainSubstring(fmt.Sprint("nodePort=", nodePort)))
+		})
+	})
+})
+
+func makeKubelet(defaultPort int, client *http.Client, addrResolver utils.NodeAddressResolver, KubeletProxyServerAddress string) *kubeletClient {
+	res := &kubeletClient{
+		defaultPort:               defaultPort,
+		useNodeStatusPort:         false,
+		client:                    client,
+		scheme:                    "http",
+		addrResolver:              addrResolver,
+		KubeletProxyServerAddress: KubeletProxyServerAddress,
+		buffers: sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
+		},
+	}
+
+	return res
+}
+
+type MockServerResponse struct {
+	StatusCode int
+	Headers    http.Header
+	Body       []byte
+}
+
+type MockServerProcedure struct {
+	URI        string
+	HTTPMethod string
+	Response   MockServerResponse
+}
+
+type MockServerRecorder struct {
+	Requests []*http.Request
+}
+
+func newMockServer(recorder *MockServerRecorder, procedures ...MockServerProcedure) *httptest.Server {
+	var handler http.Handler
+
+	handler = http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r != nil {
+				recorder.Requests = append(recorder.Requests, r)
+			}
+
+			for _, proc := range procedures {
+				if proc.HTTPMethod == r.Method {
+					headers := w.Header()
+					for hkey, hvalue := range proc.Response.Headers {
+						headers[hkey] = hvalue
+					}
+					code := proc.Response.StatusCode
+
+					w.WriteHeader(code)
+					w.Write(proc.Response.Body)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		})
+
+	return httptest.NewServer(handler)
+}
+
+func newMockServerProcedure(url string, isSuccess bool, isProxied bool) MockServerProcedure {
+	var statusCode int
+
+	if isSuccess {
+		statusCode = http.StatusOK
+	} else {
+		statusCode = http.StatusNotFound
+	}
+
+	res := MockServerProcedure{
+		URI:        url,
+		HTTPMethod: http.MethodGet,
+		Response: MockServerResponse{
+			StatusCode: statusCode,
+			Body:       []byte(`{"result": "ok"}`),
+		},
+	}
+
+	return res
+}

--- a/pkg/scraper/configs.go
+++ b/pkg/scraper/configs.go
@@ -28,11 +28,12 @@ import (
 
 // KubeletClientConfig represents configuration for connecting to Kubelets.
 type KubeletClientConfig struct {
-	Client              rest.Config
-	AddressTypePriority []corev1.NodeAddressType
-	Scheme              string
-	DefaultPort         int
-	UseNodeStatusPort   bool
+	Client                    rest.Config
+	AddressTypePriority       []corev1.NodeAddressType
+	Scheme                    string
+	DefaultPort               int
+	UseNodeStatusPort         bool
+	KubeletProxyServerAddress string
 }
 
 // Complete constructs a new kubeletCOnfig for the given configuration.
@@ -46,11 +47,12 @@ func (config KubeletClientConfig) Complete() (*kubeletClient, error) {
 		Transport: transport,
 	}
 	return &kubeletClient{
-		addrResolver:      utils.NewPriorityNodeAddressResolver(config.AddressTypePriority),
-		defaultPort:       config.DefaultPort,
-		client:            c,
-		scheme:            config.Scheme,
-		useNodeStatusPort: config.UseNodeStatusPort,
+		addrResolver:              utils.NewPriorityNodeAddressResolver(config.AddressTypePriority),
+		defaultPort:               config.DefaultPort,
+		client:                    c,
+		scheme:                    config.Scheme,
+		useNodeStatusPort:         config.UseNodeStatusPort,
+		KubeletProxyServerAddress: config.KubeletProxyServerAddress,
 		buffers: sync.Pool{
 			New: func() interface{} {
 				return new(bytes.Buffer)

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -52,10 +52,10 @@ var _ = Describe("Scraper", func() {
 		scrapeTime = time.Now()
 		nodeLister fakeNodeLister
 		client     fakeKubeletClient
-		node1      = makeNode("node1", "node1.somedomain", "10.0.1.2", true)
-		node2      = makeNode("node-no-host", "", "10.0.1.3", true)
-		node3      = makeNode("node3", "node3.somedomain", "10.0.1.4", false)
-		node4      = makeNode("node4", "node4.somedomain", "10.0.1.5", true)
+		node1      = makeNode("node1", "node1.somedomain", "10.0.1.2", true, false)
+		node2      = makeNode("node-no-host", "", "10.0.1.3", true, false)
+		node3      = makeNode("node3", "node3.somedomain", "10.0.1.4", false, false)
+		node4      = makeNode("node4", "node4.somedomain", "10.0.1.5", true, false)
 	)
 	BeforeEach(func() {
 		summary := &Summary{
@@ -271,7 +271,7 @@ func (l *fakeNodeLister) Get(name string) (*corev1.Node, error) {
 	return nil, fmt.Errorf("no such node %q", name)
 }
 
-func makeNode(name, hostName, addr string, ready bool) *corev1.Node {
+func makeNode(name, hostName, addr string, ready bool, useProxy bool) *corev1.Node {
 	res := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Status: corev1.NodeStatus{
@@ -291,6 +291,9 @@ func makeNode(name, hostName, addr string, ready bool) *corev1.Node {
 		res.Status.Conditions[0].Status = corev1.ConditionTrue
 	} else {
 		res.Status.Conditions[0].Status = corev1.ConditionFalse
+	}
+	if useProxy {
+		res.ObjectMeta.Labels = map[string]string{"usingMetricsProxy": "true"}
 	}
 	return res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Nodes running on a different network can't be reached by the metrics-server, and setting up a tunnel is not an option. This PR allows us to specify a reverse proxy server to reach those nodes. Nodes are labelled using "usingMetricsProxy=true" if a proxy server is needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

